### PR TITLE
security(main): Pin 3rd-party Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,6 +37,6 @@ jobs:
       run: |
         uv run pdoc src/MoBI_View -o docs_build -t docs/pdoc-theme --docformat google
         touch docs_build/.nojekyll
-    - uses: JamesIves/github-pages-deploy-action@v4
+    - uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
       with:
         folder: docs_build

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -27,7 +27,7 @@ jobs:
         python-version-file: pyproject.toml
     
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
       with:
         enable-cache: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
       shell: pwsh
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true


### PR DESCRIPTION
### Task
Enhance CI workflow security by pinning third-party GitHub Actions to specific commit SHAs.

### Description
This PR updates the `.github/workflows/pypi.yaml`, `.github/workflows/test.yaml`, and `.github/workflows/docs.yaml` workflow files to replace version tags with full commit SHAs for all third-party GitHub Actions.