### PR TITLE
feat(discovery): Implement centralized stream discovery module and changing import level to be consistent

### DIFF
--- a/src/MoBI_View/core/config.py
+++ b/src/MoBI_View/core/config.py
@@ -12,9 +12,12 @@ class Config:
         TIMER_INTERVAL: Timer interval in milliseconds for data acquisition.
         MAX_SAMPLES: Maximum number of samples to display (for numeric and EEG widgets).
         EEG_OFFSET: Vertical offset between EEG channels in the plot (for EEG widgets).
+        STREAM_RESOLVE_WAIT_TIME: Time in seconds to wait for LSL stream discovery.
+            LSL recommends 1.0s (default) or 2.0s for busy networks. Minimum 0.5s.
     """
 
     BUFFER_SIZE: int = 1000
     TIMER_INTERVAL: int = 50
     MAX_SAMPLES: int = 500
     EEG_OFFSET: int = 50
+    STREAM_RESOLVE_WAIT_TIME: float = 1.0

--- a/src/MoBI_View/core/config.py
+++ b/src/MoBI_View/core/config.py
@@ -14,6 +14,7 @@ class Config:
         EEG_OFFSET: Vertical offset between EEG channels in the plot (for EEG widgets).
         STREAM_RESOLVE_WAIT_TIME: Time in seconds to wait for LSL stream discovery.
             LSL recommends 1.0s (default) or 2.0s for busy networks. Minimum 0.5s.
+            Validation (positive, >= 0.5s) is performed in discover_and_create_inlets().
     """
 
     BUFFER_SIZE: int = 1000

--- a/src/MoBI_View/core/data_inlet.py
+++ b/src/MoBI_View/core/data_inlet.py
@@ -6,9 +6,9 @@ The DataInlet class is responsible for acquiring and buffering data from LSL str
 from typing import Dict, List
 
 import numpy as np
-from pylsl.info import StreamInfo
-from pylsl.inlet import StreamInlet
-from pylsl.util import LostError
+from pylsl import info as pylsl_info
+from pylsl import inlet as pylsl_inlet
+from pylsl import util as pylsl_util
 
 from MoBI_View.core import config, exceptions
 
@@ -32,7 +32,7 @@ class DataInlet:
         ptr: Pointer to the current index in the buffer.
     """
 
-    def __init__(self, partial_info: StreamInfo) -> None:
+    def __init__(self, partial_info: pylsl_info.StreamInfo) -> None:
         """Initializes the DataInlet instance and performs initial validation.
 
         Sets up the LSL stream inlet, extracts channel information (including the
@@ -48,8 +48,8 @@ class DataInlet:
             InvalidChannelCountError: If the stream has no channels.
             InvalidChannelFormatError: If the sample data type is invalid.
         """
-        self.inlet = StreamInlet(partial_info)
-        info: StreamInfo = self.inlet.info()
+        self.inlet = pylsl_inlet.StreamInlet(partial_info)
+        info: pylsl_info.StreamInfo = self.inlet.info()
 
         self.stream_name: str = info.name()
         self.stream_type: str = info.type()
@@ -74,7 +74,9 @@ class DataInlet:
                 "Unable to plot non-numeric data."
             )
 
-    def get_channel_information(self, info: StreamInfo) -> Dict[str, List[str]]:
+    def get_channel_information(
+        self, info: pylsl_info.StreamInfo
+    ) -> Dict[str, List[str]]:
         """Extracts channel information from the StreamInfo.
 
         Gathers channel-specific information from the LSL StreamInfo object, such as
@@ -130,5 +132,5 @@ class DataInlet:
             if sample:
                 self.buffers[self.ptr % config.Config.BUFFER_SIZE] = sample
                 self.ptr += 1
-        except LostError:
+        except pylsl_util.LostError:
             raise exceptions.StreamLostError("Stream source has been lost.")

--- a/src/MoBI_View/core/data_inlet.py
+++ b/src/MoBI_View/core/data_inlet.py
@@ -27,7 +27,6 @@ class DataInlet:
         channel_info: Information about channels, including labels, types, and units.
         channel_count: The number of channels in the LSL stream.
         channel_format: The format (data type) of the channel data.
-        sample_rate: The nominal sampling frequency reported by the stream.
         buffers: Buffer to store incoming samples, initialized to zeros.
         ptr: Pointer to the current index in the buffer.
     """
@@ -35,10 +34,9 @@ class DataInlet:
     def __init__(self, partial_info: pylsl_info.StreamInfo) -> None:
         """Initializes the DataInlet instance and performs initial validation.
 
-        Sets up the LSL stream inlet, extracts channel information (including the
-        nominal sampling rate), initializes the buffer for storing incoming data
-        samples, and validates the channel count and channel format to ensure
-        compatibility.
+        Sets up the LSL stream inlet, extracts channel information, initializes
+        the buffer for storing incoming data samples, and validates the channel
+        count and channel format to ensure compatibility.
 
         Args:
             partial_info: The partial StreamInfo from resolve_streams().
@@ -57,7 +55,6 @@ class DataInlet:
         self.channel_info: Dict[str, List[str]] = self.get_channel_information(info)
         self.channel_count: int = info.channel_count()
         self.channel_format: int = info.channel_format()
-        self.sample_rate: float = float(info.nominal_srate() or 0.0)
         self.buffers: np.ndarray = np.zeros(
             (config.Config.BUFFER_SIZE, self.channel_count)
         )

--- a/src/MoBI_View/core/data_inlet.py
+++ b/src/MoBI_View/core/data_inlet.py
@@ -23,9 +23,11 @@ class DataInlet:
         inlet: The LSL stream inlet for acquiring data.
         stream_name: The name of the LSL stream.
         stream_type: The content type of the LSL stream (e.g., EEG, Gaze).
+        source_id: The source ID of the LSL stream (unique identifier).
         channel_info: Information about channels, including labels, types, and units.
         channel_count: The number of channels in the LSL stream.
         channel_format: The format (data type) of the channel data.
+        sample_rate: The nominal sampling frequency reported by the stream.
         buffers: Buffer to store incoming samples, initialized to zeros.
         ptr: Pointer to the current index in the buffer.
     """
@@ -33,9 +35,10 @@ class DataInlet:
     def __init__(self, partial_info: StreamInfo) -> None:
         """Initializes the DataInlet instance and performs initial validation.
 
-        Sets up the LSL stream inlet, extracts channel information, initializes the
-        buffer for storing incoming data samples, and validates the channel count
-        and channel format to ensure compatibility.
+        Sets up the LSL stream inlet, extracts channel information (including the
+        nominal sampling rate), initializes the buffer for storing incoming data
+        samples, and validates the channel count and channel format to ensure
+        compatibility.
 
         Args:
             partial_info: The partial StreamInfo from resolve_streams().
@@ -50,9 +53,11 @@ class DataInlet:
 
         self.stream_name: str = info.name()
         self.stream_type: str = info.type()
+        self.source_id: str = info.source_id()
         self.channel_info: Dict[str, List[str]] = self.get_channel_information(info)
         self.channel_count: int = info.channel_count()
         self.channel_format: int = info.channel_format()
+        self.sample_rate: float = float(info.nominal_srate() or 0.0)
         self.buffers: np.ndarray = np.zeros(
             (config.Config.BUFFER_SIZE, self.channel_count)
         )

--- a/src/MoBI_View/core/discovery.py
+++ b/src/MoBI_View/core/discovery.py
@@ -41,8 +41,7 @@ def discover_and_create_inlets(
     existing_streams: Set[Tuple[str, str]] = set()
     if existing_inlets:
         existing_streams = {
-            (inlet.stream_name, inlet.stream_type)
-            for inlet in existing_inlets
+            (inlet.stream_name, inlet.stream_type) for inlet in existing_inlets
         }
 
     try:

--- a/src/MoBI_View/core/discovery.py
+++ b/src/MoBI_View/core/discovery.py
@@ -26,7 +26,8 @@ def discover_and_create_inlets(
     """Discover LSL streams and create DataInlet instances.
 
     This function resolves available LSL streams and creates DataInlet instances
-    for any new streams not already in the existing_inlets list.
+    for any new streams not already in the existing_inlets list. Deduplication is
+    based on (stream_name, stream_type) tuple.
 
     Args:
         wait_time: How long to wait for streams to be discovered (seconds).
@@ -37,10 +38,10 @@ def discover_and_create_inlets(
     """
     new_inlets: List[DataInlet] = []
 
-    existing_streams: Set[Tuple[str, str, str]] = set()
+    existing_streams: Set[Tuple[str, str]] = set()
     if existing_inlets:
         existing_streams = {
-            (inlet.source_id, inlet.stream_name, inlet.stream_type)
+            (inlet.stream_name, inlet.stream_type)
             for inlet in existing_inlets
         }
 
@@ -49,10 +50,9 @@ def discover_and_create_inlets(
 
         for info in discovered_streams:
             try:
-                source_id = info.source_id()
                 stream_name = info.name()
                 stream_type = info.type()
-                stream_id = (source_id, stream_name, stream_type)
+                stream_id = (stream_name, stream_type)
 
                 if stream_id in existing_streams:
                     continue

--- a/src/MoBI_View/main.py
+++ b/src/MoBI_View/main.py
@@ -4,28 +4,22 @@ Discovers LSL streams, creates DataInlets and MainAppPresenter, then starts
 the WebSocket server with browser interface.
 """
 
-import asyncio
 import logging
 import threading
 import webbrowser
 
-from MoBI_View.core.config import Config
 from MoBI_View.core.discovery import discover_and_create_inlets
 from MoBI_View.presenters.main_app_presenter import MainAppPresenter
-from MoBI_View.web.server import run_server
 
 
 def schedule_browser_launch() -> None:
     """Opens browser to application URL after short delay."""
 
     def _launch() -> None:
-        host = Config.HTTP_HOST
-        if host in {"0.0.0.0", "::"}:
-            host_display = "localhost"
-        else:
-            host_display = host
-        port = Config.HTTP_PORT
-        url = f"http://{host_display}:{port}"
+        # Default host and port - will be configurable in future branch
+        host = "localhost"
+        port = 8765
+        url = f"http://{host}:{port}"
         try:
             webbrowser.open(url, new=2, autoraise=True)
         except webbrowser.Error as exc:  # pragma: no cover
@@ -37,21 +31,20 @@ def schedule_browser_launch() -> None:
 
 
 def main() -> None:
-    """Discovers LSL streams and starts web server with browser interface."""
+    """Discovers LSL streams and creates presenter (web server in future branch)."""
     print("Discovering LSL streams...")
 
     inlets, count = discover_and_create_inlets(wait_time=1.0)
 
     if count == 0:
-        print("No LSL streams found. Server will start with empty stream list.")
-        print("Use the 'Discover Streams' button in the web UI to search for streams.")
+        print("No LSL streams found.")
+        print("Future: Use 'Discover Streams' button in web UI to search for streams.")
     else:
         print(f"Found {count} stream(s)")
 
     presenter = MainAppPresenter(data_inlets=inlets)
-
-    schedule_browser_launch()
-    asyncio.run(run_server(presenter))
+    print(f"Created presenter with {len(presenter.data_inlets)} inlet(s)")
+    print("Note: Web server functionality will be added in future branch")
 
 
 if __name__ == "__main__":

--- a/src/MoBI_View/main.py
+++ b/src/MoBI_View/main.py
@@ -11,6 +11,14 @@ import webbrowser
 from MoBI_View.core import discovery
 from MoBI_View.presenters import main_app_presenter
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+logger = logging.getLogger("MoBI-View.main")
+
 
 def schedule_browser_launch() -> None:
     """Opens browser to application URL after short delay."""
@@ -22,7 +30,7 @@ def schedule_browser_launch() -> None:
         try:
             webbrowser.open(url, new=2, autoraise=True)
         except webbrowser.Error as exc:  # pragma: no cover
-            logging.getLogger(__name__).warning("Browser launch failed: %s", exc)
+            logger.warning("Browser launch failed: %s", exc)
 
     timer = threading.Timer(0.5, _launch)
     timer.daemon = True
@@ -31,19 +39,21 @@ def schedule_browser_launch() -> None:
 
 def main() -> None:
     """Discovers LSL streams and creates presenter (web server in future branch)."""
-    print("Discovering LSL streams...")
+    logger.info("Discovering LSL streams...")
 
     inlets = discovery.discover_and_create_inlets()
 
     if not inlets:
-        print("No LSL streams found.")
-        print("Future: Use 'Discover Streams' button in web UI to search for streams.")
+        logger.info("No LSL streams found.")
+        logger.info(
+            "Future: Use 'Discover Streams' button in web UI to search for streams."
+        )
     else:
-        print(f"Found {len(inlets)} stream(s)")
+        logger.info("Found %d stream(s)", len(inlets))
 
     presenter = main_app_presenter.MainAppPresenter(data_inlets=inlets)
-    print(f"Created presenter with {len(presenter.data_inlets)} inlet(s)")
-    print("Note: Web server functionality will be added in future branch")
+    logger.info("Created presenter with %d inlet(s)", len(presenter.data_inlets))
+    logger.info("Note: Web server functionality will be added in future branch")
 
 
 if __name__ == "__main__":

--- a/src/MoBI_View/main.py
+++ b/src/MoBI_View/main.py
@@ -8,15 +8,14 @@ import logging
 import threading
 import webbrowser
 
-from MoBI_View.core.discovery import discover_and_create_inlets
-from MoBI_View.presenters.main_app_presenter import MainAppPresenter
+from MoBI_View.core import discovery
+from MoBI_View.presenters import main_app_presenter
 
 
 def schedule_browser_launch() -> None:
     """Opens browser to application URL after short delay."""
 
     def _launch() -> None:
-        # Default host and port - will be configurable in future branch
         host = "localhost"
         port = 8765
         url = f"http://{host}:{port}"
@@ -34,15 +33,15 @@ def main() -> None:
     """Discovers LSL streams and creates presenter (web server in future branch)."""
     print("Discovering LSL streams...")
 
-    inlets, count = discover_and_create_inlets(wait_time=1.0)
+    inlets = discovery.discover_and_create_inlets(wait_time=1.0)
 
-    if count == 0:
+    if not inlets:
         print("No LSL streams found.")
         print("Future: Use 'Discover Streams' button in web UI to search for streams.")
     else:
-        print(f"Found {count} stream(s)")
+        print(f"Found {len(inlets)} stream(s)")
 
-    presenter = MainAppPresenter(data_inlets=inlets)
+    presenter = main_app_presenter.MainAppPresenter(data_inlets=inlets)
     print(f"Created presenter with {len(presenter.data_inlets)} inlet(s)")
     print("Note: Web server functionality will be added in future branch")
 

--- a/src/MoBI_View/main.py
+++ b/src/MoBI_View/main.py
@@ -33,7 +33,7 @@ def main() -> None:
     """Discovers LSL streams and creates presenter (web server in future branch)."""
     print("Discovering LSL streams...")
 
-    inlets = discovery.discover_and_create_inlets(wait_time=1.0)
+    inlets = discovery.discover_and_create_inlets()
 
     if not inlets:
         print("No LSL streams found.")

--- a/tests/unit/test_data_inlet.py
+++ b/tests/unit/test_data_inlet.py
@@ -41,6 +41,7 @@ def mock_lsl_info(
 
     info.name.return_value = "MockStreamName"
     info.type.return_value = "MockStreamType"
+    info.source_id.return_value = "MockSourceID"
 
     return (
         info,
@@ -107,6 +108,7 @@ def test_initialization(
 
     expected_name = info.name.return_value
     expected_type = info.type.return_value
+    expected_source_id = info.source_id.return_value
 
     assert data_inlet_instance.channel_count == channel_count
     assert data_inlet_instance.channel_format == channel_format
@@ -120,6 +122,7 @@ def test_initialization(
     assert data_inlet_instance.channel_info["units"] == channel_units
     assert data_inlet_instance.stream_name == expected_name
     assert data_inlet_instance.stream_type == expected_type
+    assert data_inlet_instance.source_id == expected_source_id
 
 
 def test_get_channel_information(

--- a/tests/unit/test_data_inlet.py
+++ b/tests/unit/test_data_inlet.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from pylsl.info import StreamInfo
-from pylsl.inlet import StreamInlet
-from pylsl.util import LostError
+from pylsl import info as pylsl_info
+from pylsl import inlet as pylsl_inlet
+from pylsl import util as pylsl_util
 from pytest_mock import MockFixture
 
 from MoBI_View.core import config, data_inlet, exceptions
@@ -31,7 +31,7 @@ def mock_lsl_info(
     channel_types = ["Gaze position", "Gaze position", "Pupil diameter"]
     channel_units = ["px", "px", "mm"]
 
-    info = mocker.MagicMock(spec=StreamInfo)
+    info = mocker.MagicMock(spec=pylsl_info.StreamInfo)
     info.channel_count.return_value = channel_count
     info.channel_format.return_value = channel_format
 
@@ -62,7 +62,7 @@ def mock_stream_inlet(mocker: MockFixture) -> Tuple[MagicMock, List[float]]:
     """
     sample_data = [1.0, 2.0, 3.0]
 
-    inlet = mocker.MagicMock(spec=StreamInlet)
+    inlet = mocker.MagicMock(spec=pylsl_inlet.StreamInlet)
     inlet.pull_sample = mocker.MagicMock(return_value=(sample_data, 0.0))
     return inlet, sample_data
 
@@ -78,7 +78,7 @@ def data_inlet_instance(
     inlet, _ = mock_stream_inlet
 
     mock_stream = mocker.patch(
-        "MoBI_View.core.data_inlet.StreamInlet", return_value=inlet
+        "MoBI_View.core.data_inlet.pylsl_inlet.StreamInlet", return_value=inlet
     )
     mock_stream.return_value.info.return_value = info
     return data_inlet.DataInlet(info)
@@ -223,7 +223,8 @@ def test_invalid_channel_count(
     info.channel_count.return_value = 0
 
     mock_stream = mocker.patch(
-        "MoBI_View.core.data_inlet.StreamInlet", return_value=mocker.MagicMock()
+        "MoBI_View.core.data_inlet.pylsl_inlet.StreamInlet",
+        return_value=mocker.MagicMock(),
     )
     mock_stream.return_value.info.return_value = info
     with pytest.raises(
@@ -253,7 +254,8 @@ def test_invalid_channel_format(
     info.channel_format.return_value = invalid_channel_format
 
     mock_stream = mocker.patch(
-        "MoBI_View.core.data_inlet.StreamInlet", return_value=mocker.MagicMock()
+        "MoBI_View.core.data_inlet.pylsl_inlet.StreamInlet",
+        return_value=mocker.MagicMock(),
     )
     mock_stream.return_value.info.return_value = info
     with pytest.raises(
@@ -283,7 +285,8 @@ def test_valid_channel_format(
     info.channel_format.return_value = valid_channel_format
 
     mock_stream = mocker.patch(
-        "MoBI_View.core.data_inlet.StreamInlet", return_value=mocker.MagicMock()
+        "MoBI_View.core.data_inlet.pylsl_inlet.StreamInlet",
+        return_value=mocker.MagicMock(),
     )
     mock_stream.return_value.info.return_value = info
     inlet = data_inlet.DataInlet(info)
@@ -326,7 +329,7 @@ def test_pull_sample_stream_lost(
         mock_stream_inlet: Fixture providing mock StreamInlet.
     """
     inlet, _ = mock_stream_inlet
-    inlet.pull_sample.side_effect = LostError
+    inlet.pull_sample.side_effect = pylsl_util.LostError
 
     with pytest.raises(
         exceptions.StreamLostError, match="Stream source has been lost."

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -58,7 +58,6 @@ def test_discover_and_create_inlets_finds_new_streams(
     mock_stream_info_factory: Callable[..., MagicMock],
 ) -> None:
     """discover_and_create_inlets should create DataInlets for discovered streams."""
-    # Mock resolve_streams to return 2 streams
     stream1 = mock_stream_info_factory(name="Stream1", source_id="source1")
     stream2 = mock_stream_info_factory(name="Stream2", source_id="source2")
 
@@ -67,7 +66,6 @@ def test_discover_and_create_inlets_finds_new_streams(
         return_value=[stream1, stream2],
     )
 
-    # Mock DataInlet constructor
     mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
     mock_inlet1 = MagicMock()
     mock_inlet1.stream_name = "Stream1"
@@ -111,14 +109,12 @@ def test_discover_and_create_inlets_deduplicates_existing_streams(
     mock_data_inlet_factory: Callable[..., MagicMock],
 ) -> None:
     """discover_and_create_inlets should skip streams that already exist."""
-    # Create existing inlet
     existing_inlet = mock_data_inlet_factory(
         stream_name="ExistingStream",
         source_id="existing_source",
         stream_type="EEG",
     )
 
-    # Mock discovery to find existing stream + new stream
     existing_stream_info = mock_stream_info_factory(
         name="ExistingStream",
         source_id="existing_source",
@@ -135,7 +131,6 @@ def test_discover_and_create_inlets_deduplicates_existing_streams(
         return_value=[existing_stream_info, new_stream_info],
     )
 
-    # Mock DataInlet constructor
     mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
     mock_new_inlet = MagicMock()
     mock_new_inlet.stream_name = "NewStream"
@@ -149,7 +144,6 @@ def test_discover_and_create_inlets_deduplicates_existing_streams(
         existing_inlets=[existing_inlet],
     )
 
-    # Should only create inlet for new stream
     assert count == 1
     assert len(inlets) == 1
     assert mock_inlet_class.call_count == 1
@@ -161,7 +155,6 @@ def test_discover_and_create_inlets_handles_inlet_creation_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """discover_and_create_inlets should skip streams that fail to create inlets."""
-    # Mock resolve_streams to return 2 streams
     stream1 = mock_stream_info_factory(name="BadStream", source_id="bad_source")
     stream2 = mock_stream_info_factory(name="GoodStream", source_id="good_source")
 
@@ -170,7 +163,6 @@ def test_discover_and_create_inlets_handles_inlet_creation_error(
         return_value=[stream1, stream2],
     )
 
-    # Mock DataInlet constructor to fail on first call, succeed on second
     mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
     mock_good_inlet = MagicMock()
     mock_good_inlet.stream_name = "GoodStream"
@@ -184,13 +176,10 @@ def test_discover_and_create_inlets_handles_inlet_creation_error(
     ]
 
     inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+    captured = capsys.readouterr()
 
-    # Should only create inlet for good stream
     assert count == 1
     assert len(inlets) == 1
-
-    # Should print error message
-    captured = capsys.readouterr()
     assert "Skipping stream BadStream" in captured.out
 
 
@@ -205,12 +194,10 @@ def test_discover_and_create_inlets_handles_resolve_error(
     )
 
     inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+    captured = capsys.readouterr()
 
     assert count == 0
     assert len(inlets) == 0
-
-    # Should print error message
-    captured = capsys.readouterr()
     assert "Error during stream discovery" in captured.out
 
 
@@ -236,8 +223,8 @@ def test_discover_and_create_inlets_prints_discovered_streams(
     mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_inlet)
 
     discovery.discover_and_create_inlets(wait_time=0.5)
-
     captured = capsys.readouterr()
+
     assert "Discovered new stream: TestStream" in captured.out
     assert "8 channels" in captured.out
 
@@ -277,21 +264,18 @@ def test_discover_and_create_inlets_deduplicates_by_source_name_type(
     mock_data_inlet_factory: Callable[..., MagicMock],
 ) -> None:
     """discover_and_create_inlets should deduplicate using (source_id, name, type)."""
-    # Existing inlet with specific source_id, name, type
     existing = mock_data_inlet_factory(
         stream_name="MyStream",
         source_id="source123",
         stream_type="EEG",
     )
 
-    # Try to discover same stream again (should be skipped)
     same_stream = mock_stream_info_factory(
         name="MyStream",
         source_id="source123",
         stream_type="EEG",
     )
 
-    # Different stream with same name but different source_id (should be added)
     different_stream = mock_stream_info_factory(
         name="MyStream",
         source_id="source456",
@@ -316,6 +300,5 @@ def test_discover_and_create_inlets_deduplicates_by_source_name_type(
         existing_inlets=[existing],
     )
 
-    # Should only create inlet for different stream
     assert count == 1
     assert len(inlets) == 1

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -164,9 +164,9 @@ def test_wait_time_validation(
     mocker: MockFixture,
     mock_stream_info_factory: Callable[..., MagicMock],
     caplog: pytest.LogCaptureFixture,
-    wait_time_input: float | None,
+    wait_time_input: float,
     expected_value: float,
-    expected_log_fragment: str | None,
+    expected_log_fragment: str,
 ) -> None:
     """Test wait_time validation and defaults."""
     stream = mock_stream_info_factory(name="Stream")

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,321 @@
+"""Unit tests for the discovery module."""
+
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from pylsl import StreamInfo
+from pytest_mock import MockFixture
+
+from MoBI_View.core import discovery
+from MoBI_View.core.data_inlet import DataInlet
+
+
+@pytest.fixture
+def mock_stream_info_factory() -> Callable[..., MagicMock]:
+    """Factory for creating mock StreamInfo objects."""
+
+    def _factory(
+        name: str = "TestStream",
+        stream_type: str = "EEG",
+        source_id: str = "test_source_123",
+        channel_count: int = 3,
+    ) -> MagicMock:
+        info = MagicMock(spec=StreamInfo)
+        info.name.return_value = name
+        info.type.return_value = stream_type
+        info.source_id.return_value = source_id
+        info.channel_count.return_value = channel_count
+        info.channel_format.return_value = 1  # float32
+        info.get_channel_labels.return_value = [f"Ch{i}" for i in range(channel_count)]
+        info.get_channel_types.return_value = ["EEG"] * channel_count
+        info.get_channel_units.return_value = ["uV"] * channel_count
+        return info
+
+    return _factory
+
+
+@pytest.fixture
+def mock_data_inlet_factory() -> Callable[..., MagicMock]:
+    """Factory for creating mock DataInlet objects."""
+
+    def _factory(
+        stream_name: str = "TestStream",
+        stream_type: str = "EEG",
+        source_id: str = "test_source_123",
+    ) -> MagicMock:
+        inlet = MagicMock(spec=DataInlet)
+        inlet.stream_name = stream_name
+        inlet.stream_type = stream_type
+        inlet.source_id = source_id
+        return inlet
+
+    return _factory
+
+
+def test_discover_and_create_inlets_finds_new_streams(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+) -> None:
+    """discover_and_create_inlets should create DataInlets for discovered streams."""
+    # Mock resolve_streams to return 2 streams
+    stream1 = mock_stream_info_factory(name="Stream1", source_id="source1")
+    stream2 = mock_stream_info_factory(name="Stream2", source_id="source2")
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[stream1, stream2],
+    )
+
+    # Mock DataInlet constructor
+    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
+    mock_inlet1 = MagicMock()
+    mock_inlet1.stream_name = "Stream1"
+    mock_inlet1.stream_type = "EEG"
+    mock_inlet1.source_id = "source1"
+    mock_inlet1.channel_count = 3
+
+    mock_inlet2 = MagicMock()
+    mock_inlet2.stream_name = "Stream2"
+    mock_inlet2.stream_type = "EEG"
+    mock_inlet2.source_id = "source2"
+    mock_inlet2.channel_count = 3
+
+    mock_inlet_class.side_effect = [mock_inlet1, mock_inlet2]
+
+    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+
+    assert count == 2
+    assert len(inlets) == 2
+    assert mock_inlet_class.call_count == 2
+
+
+def test_discover_and_create_inlets_with_no_streams(
+    mocker: MockFixture,
+) -> None:
+    """discover_and_create_inlets should return empty list when no streams found."""
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[],
+    )
+
+    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+
+    assert count == 0
+    assert len(inlets) == 0
+
+
+def test_discover_and_create_inlets_deduplicates_existing_streams(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+    mock_data_inlet_factory: Callable[..., MagicMock],
+) -> None:
+    """discover_and_create_inlets should skip streams that already exist."""
+    # Create existing inlet
+    existing_inlet = mock_data_inlet_factory(
+        stream_name="ExistingStream",
+        source_id="existing_source",
+        stream_type="EEG",
+    )
+
+    # Mock discovery to find existing stream + new stream
+    existing_stream_info = mock_stream_info_factory(
+        name="ExistingStream",
+        source_id="existing_source",
+        stream_type="EEG",
+    )
+    new_stream_info = mock_stream_info_factory(
+        name="NewStream",
+        source_id="new_source",
+        stream_type="EMG",
+    )
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[existing_stream_info, new_stream_info],
+    )
+
+    # Mock DataInlet constructor
+    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
+    mock_new_inlet = MagicMock()
+    mock_new_inlet.stream_name = "NewStream"
+    mock_new_inlet.stream_type = "EMG"
+    mock_new_inlet.source_id = "new_source"
+    mock_new_inlet.channel_count = 2
+    mock_inlet_class.return_value = mock_new_inlet
+
+    inlets, count = discovery.discover_and_create_inlets(
+        wait_time=0.5,
+        existing_inlets=[existing_inlet],
+    )
+
+    # Should only create inlet for new stream
+    assert count == 1
+    assert len(inlets) == 1
+    assert mock_inlet_class.call_count == 1
+
+
+def test_discover_and_create_inlets_handles_inlet_creation_error(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """discover_and_create_inlets should skip streams that fail to create inlets."""
+    # Mock resolve_streams to return 2 streams
+    stream1 = mock_stream_info_factory(name="BadStream", source_id="bad_source")
+    stream2 = mock_stream_info_factory(name="GoodStream", source_id="good_source")
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[stream1, stream2],
+    )
+
+    # Mock DataInlet constructor to fail on first call, succeed on second
+    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
+    mock_good_inlet = MagicMock()
+    mock_good_inlet.stream_name = "GoodStream"
+    mock_good_inlet.stream_type = "EEG"
+    mock_good_inlet.source_id = "good_source"
+    mock_good_inlet.channel_count = 3
+
+    mock_inlet_class.side_effect = [
+        RuntimeError("Failed to create inlet"),
+        mock_good_inlet,
+    ]
+
+    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+
+    # Should only create inlet for good stream
+    assert count == 1
+    assert len(inlets) == 1
+
+    # Should print error message
+    captured = capsys.readouterr()
+    assert "Skipping stream BadStream" in captured.out
+
+
+def test_discover_and_create_inlets_handles_resolve_error(
+    mocker: MockFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """discover_and_create_inlets should handle errors from resolve_streams."""
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        side_effect=RuntimeError("Network error"),
+    )
+
+    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+
+    assert count == 0
+    assert len(inlets) == 0
+
+    # Should print error message
+    captured = capsys.readouterr()
+    assert "Error during stream discovery" in captured.out
+
+
+def test_discover_and_create_inlets_prints_discovered_streams(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """discover_and_create_inlets should print info about discovered streams."""
+    stream = mock_stream_info_factory(name="TestStream", channel_count=8)
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[stream],
+    )
+
+    mock_inlet = MagicMock()
+    mock_inlet.stream_name = "TestStream"
+    mock_inlet.stream_type = "EEG"
+    mock_inlet.source_id = "test_source"
+    mock_inlet.channel_count = 8
+
+    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_inlet)
+
+    discovery.discover_and_create_inlets(wait_time=0.5)
+
+    captured = capsys.readouterr()
+    assert "Discovered new stream: TestStream" in captured.out
+    assert "8 channels" in captured.out
+
+
+def test_discover_and_create_inlets_with_empty_existing_list(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+) -> None:
+    """discover_and_create_inlets should handle empty existing_inlets list."""
+    stream = mock_stream_info_factory(name="Stream1")
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[stream],
+    )
+
+    mock_inlet = MagicMock()
+    mock_inlet.stream_name = "Stream1"
+    mock_inlet.stream_type = "EEG"
+    mock_inlet.source_id = "source1"
+    mock_inlet.channel_count = 3
+
+    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_inlet)
+
+    inlets, count = discovery.discover_and_create_inlets(
+        wait_time=0.5,
+        existing_inlets=[],
+    )
+
+    assert count == 1
+    assert len(inlets) == 1
+
+
+def test_discover_and_create_inlets_deduplicates_by_source_name_type(
+    mocker: MockFixture,
+    mock_stream_info_factory: Callable[..., MagicMock],
+    mock_data_inlet_factory: Callable[..., MagicMock],
+) -> None:
+    """discover_and_create_inlets should deduplicate using (source_id, name, type)."""
+    # Existing inlet with specific source_id, name, type
+    existing = mock_data_inlet_factory(
+        stream_name="MyStream",
+        source_id="source123",
+        stream_type="EEG",
+    )
+
+    # Try to discover same stream again (should be skipped)
+    same_stream = mock_stream_info_factory(
+        name="MyStream",
+        source_id="source123",
+        stream_type="EEG",
+    )
+
+    # Different stream with same name but different source_id (should be added)
+    different_stream = mock_stream_info_factory(
+        name="MyStream",
+        source_id="source456",
+        stream_type="EEG",
+    )
+
+    mocker.patch(
+        "MoBI_View.core.discovery.resolve_streams",
+        return_value=[same_stream, different_stream],
+    )
+
+    mock_new_inlet = MagicMock()
+    mock_new_inlet.stream_name = "MyStream"
+    mock_new_inlet.stream_type = "EEG"
+    mock_new_inlet.source_id = "source456"
+    mock_new_inlet.channel_count = 3
+
+    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_new_inlet)
+
+    inlets, count = discovery.discover_and_create_inlets(
+        wait_time=0.5,
+        existing_inlets=[existing],
+    )
+
+    # Should only create inlet for different stream
+    assert count == 1
+    assert len(inlets) == 1

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -263,22 +263,19 @@ def test_discover_and_create_inlets_deduplicates_by_source_name_type(
     mock_stream_info_factory: Callable[..., MagicMock],
     mock_data_inlet_factory: Callable[..., MagicMock],
 ) -> None:
-    """discover_and_create_inlets should deduplicate using (source_id, name, type)."""
+    """discover_and_create_inlets should deduplicate using (name, type)."""
     existing = mock_data_inlet_factory(
         stream_name="MyStream",
-        source_id="source123",
         stream_type="EEG",
     )
 
     same_stream = mock_stream_info_factory(
         name="MyStream",
-        source_id="source123",
         stream_type="EEG",
     )
 
     different_stream = mock_stream_info_factory(
-        name="MyStream",
-        source_id="source456",
+        name="DifferentStream",
         stream_type="EEG",
     )
 
@@ -288,9 +285,8 @@ def test_discover_and_create_inlets_deduplicates_by_source_name_type(
     )
 
     mock_new_inlet = MagicMock()
-    mock_new_inlet.stream_name = "MyStream"
+    mock_new_inlet.stream_name = "DifferentStream"
     mock_new_inlet.stream_type = "EEG"
-    mock_new_inlet.source_id = "source456"
     mock_new_inlet.channel_count = 3
 
     mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_new_inlet)

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -153,14 +153,11 @@ def test_handles_no_streams_discovered(
 @pytest.mark.parametrize(
     ("wait_time_input", "expected_value", "expected_log_fragment"),
     [
-        (None, 1.0, None),  # Uses config default
-        (2.5, 2.5, None),  # Valid explicit value
-        (0.5, 0.5, None),  # Valid edge case (minimum)
-        (-1.5, 1.0, "wait_time cannot be negative or zero"),  # Negative
-        (0, 1.0, "wait_time cannot be negative or zero"),  # Zero
-        (0.3, 0.5, "below minimum of 0.5s"),  # Below minimum
-        (float("inf"), 1.0, "Invalid wait_time value"),  # Infinity
-        ("invalid", 1.0, "Invalid wait_time value"),  # Invalid type
+        (-1.5, 1.0, "wait_time cannot be negative or zero"),
+        (0, 1.0, "wait_time cannot be negative or zero"),
+        (0.3, 0.5, "below minimum of 0.5s"),
+        (float("inf"), 1.0, "Invalid wait_time value"),
+        ("invalid", 1.0, "Invalid wait_time value"),
     ],
 )
 def test_wait_time_validation(
@@ -182,11 +179,7 @@ def test_wait_time_validation(
         "MoBI_View.core.discovery.data_inlet.DataInlet", return_value=mock_inlet
     )
 
-    if wait_time_input is None:
-        discovery.discover_and_create_inlets()
-    else:
-        discovery.discover_and_create_inlets(wait_time=wait_time_input)  # type: ignore[arg-type]
+    discovery.discover_and_create_inlets(wait_time=wait_time_input)
 
     mock_resolve.assert_called_once_with(expected_value)
-    if expected_log_fragment:
-        assert expected_log_fragment in caplog.text
+    assert expected_log_fragment in caplog.text

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -18,15 +18,15 @@ def mock_stream_info_factory() -> Callable[..., MagicMock]:
     def _factory(
         name: str = "TestStream",
         stream_type: str = "EEG",
-        source_id: str = "test_source_123",
         channel_count: int = 3,
+        source_id: str = "MockSourceID",
     ) -> MagicMock:
         info = MagicMock(spec=StreamInfo)
         info.name.return_value = name
         info.type.return_value = stream_type
-        info.source_id.return_value = source_id
         info.channel_count.return_value = channel_count
-        info.channel_format.return_value = 1  # float32
+        info.channel_format.return_value = 1
+        info.source_id.return_value = source_id
         info.get_channel_labels.return_value = [f"Ch{i}" for i in range(channel_count)]
         info.get_channel_types.return_value = ["EEG"] * channel_count
         info.get_channel_units.return_value = ["uV"] * channel_count
@@ -35,266 +35,120 @@ def mock_stream_info_factory() -> Callable[..., MagicMock]:
     return _factory
 
 
-@pytest.fixture
-def mock_data_inlet_factory() -> Callable[..., MagicMock]:
-    """Factory for creating mock DataInlet objects."""
-
-    def _factory(
-        stream_name: str = "TestStream",
-        stream_type: str = "EEG",
-        source_id: str = "test_source_123",
-    ) -> MagicMock:
-        inlet = MagicMock(spec=DataInlet)
-        inlet.stream_name = stream_name
-        inlet.stream_type = stream_type
-        inlet.source_id = source_id
-        return inlet
-
-    return _factory
-
-
-def test_discover_and_create_inlets_finds_new_streams(
+def test_happy_path_discovers_and_creates_inlets(
     mocker: MockFixture,
     mock_stream_info_factory: Callable[..., MagicMock],
 ) -> None:
-    """discover_and_create_inlets should create DataInlets for discovered streams."""
-    stream1 = mock_stream_info_factory(name="Stream1", source_id="source1")
-    stream2 = mock_stream_info_factory(name="Stream2", source_id="source2")
-
+    """Test the complete happy path: discover streams and create inlets."""
+    stream1 = mock_stream_info_factory(name="Stream1")
+    stream2 = mock_stream_info_factory(name="Stream2")
     mocker.patch(
-        "MoBI_View.core.discovery.resolve_streams",
-        return_value=[stream1, stream2],
+        "MoBI_View.core.discovery.resolve_streams", return_value=[stream1, stream2]
     )
 
-    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
-    mock_inlet1 = MagicMock()
-    mock_inlet1.stream_name = "Stream1"
-    mock_inlet1.stream_type = "EEG"
-    mock_inlet1.source_id = "source1"
-    mock_inlet1.channel_count = 3
+    mock_inlet1 = MagicMock(stream_name="Stream1", stream_type="EEG", channel_count=3)
+    mock_inlet2 = MagicMock(stream_name="Stream2", stream_type="EEG", channel_count=3)
+    mocker.patch(
+        "MoBI_View.core.discovery.DataInlet", side_effect=[mock_inlet1, mock_inlet2]
+    )
 
-    mock_inlet2 = MagicMock()
-    mock_inlet2.stream_name = "Stream2"
-    mock_inlet2.stream_type = "EEG"
-    mock_inlet2.source_id = "source2"
-    mock_inlet2.channel_count = 3
-
-    mock_inlet_class.side_effect = [mock_inlet1, mock_inlet2]
-
-    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+    inlets, count = discovery.discover_and_create_inlets(wait_time=1.0)
 
     assert count == 2
     assert len(inlets) == 2
-    assert mock_inlet_class.call_count == 2
+    assert inlets[0].stream_name == "Stream1"
+    assert inlets[1].stream_name == "Stream2"
 
 
-def test_discover_and_create_inlets_with_no_streams(
-    mocker: MockFixture,
-) -> None:
-    """discover_and_create_inlets should return empty list when no streams found."""
-    mocker.patch(
-        "MoBI_View.core.discovery.resolve_streams",
-        return_value=[],
-    )
-
-    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
-
-    assert count == 0
-    assert len(inlets) == 0
-
-
-def test_discover_and_create_inlets_deduplicates_existing_streams(
+def test_deduplicates_against_existing_inlets(
     mocker: MockFixture,
     mock_stream_info_factory: Callable[..., MagicMock],
-    mock_data_inlet_factory: Callable[..., MagicMock],
 ) -> None:
-    """discover_and_create_inlets should skip streams that already exist."""
-    existing_inlet = mock_data_inlet_factory(
-        stream_name="ExistingStream",
-        source_id="existing_source",
-        stream_type="EEG",
-    )
+    """Test deduplication: skips streams that match existing inlets."""
+    existing_inlet = MagicMock(spec=DataInlet)
+    existing_inlet.source_id = "ExistingSourceID"
+    existing_inlet.stream_name = "ExistingStream"
+    existing_inlet.stream_type = "EEG"
 
-    existing_stream_info = mock_stream_info_factory(
-        name="ExistingStream",
-        source_id="existing_source",
-        stream_type="EEG",
+    existing_stream = mock_stream_info_factory(
+        name="ExistingStream", stream_type="EEG", source_id="ExistingSourceID"
     )
-    new_stream_info = mock_stream_info_factory(
-        name="NewStream",
-        source_id="new_source",
-        stream_type="EMG",
-    )
-
+    new_stream = mock_stream_info_factory(name="NewStream", stream_type="EMG")
     mocker.patch(
         "MoBI_View.core.discovery.resolve_streams",
-        return_value=[existing_stream_info, new_stream_info],
+        return_value=[existing_stream, new_stream],
     )
 
-    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
-    mock_new_inlet = MagicMock()
-    mock_new_inlet.stream_name = "NewStream"
-    mock_new_inlet.stream_type = "EMG"
-    mock_new_inlet.source_id = "new_source"
-    mock_new_inlet.channel_count = 2
-    mock_inlet_class.return_value = mock_new_inlet
+    mock_new_inlet = MagicMock(
+        stream_name="NewStream", stream_type="EMG", channel_count=3
+    )
+    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_new_inlet)
 
     inlets, count = discovery.discover_and_create_inlets(
-        wait_time=0.5,
-        existing_inlets=[existing_inlet],
+        wait_time=1.0, existing_inlets=[existing_inlet]
     )
 
     assert count == 1
     assert len(inlets) == 1
-    assert mock_inlet_class.call_count == 1
+    assert inlets[0].stream_name == "NewStream"
 
 
-def test_discover_and_create_inlets_handles_inlet_creation_error(
-    mocker: MockFixture,
-    mock_stream_info_factory: Callable[..., MagicMock],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """discover_and_create_inlets should skip streams that fail to create inlets."""
-    stream1 = mock_stream_info_factory(name="BadStream", source_id="bad_source")
-    stream2 = mock_stream_info_factory(name="GoodStream", source_id="good_source")
-
-    mocker.patch(
-        "MoBI_View.core.discovery.resolve_streams",
-        return_value=[stream1, stream2],
-    )
-
-    mock_inlet_class = mocker.patch("MoBI_View.core.discovery.DataInlet")
-    mock_good_inlet = MagicMock()
-    mock_good_inlet.stream_name = "GoodStream"
-    mock_good_inlet.stream_type = "EEG"
-    mock_good_inlet.source_id = "good_source"
-    mock_good_inlet.channel_count = 3
-
-    mock_inlet_class.side_effect = [
-        RuntimeError("Failed to create inlet"),
-        mock_good_inlet,
-    ]
-
-    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
-    captured = capsys.readouterr()
-
-    assert count == 1
-    assert len(inlets) == 1
-    assert "Skipping stream BadStream" in captured.out
-
-
-def test_discover_and_create_inlets_handles_resolve_error(
+def test_handles_resolve_streams_failure(
     mocker: MockFixture,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """discover_and_create_inlets should handle errors from resolve_streams."""
+    """Test error handling when resolve_streams() fails."""
     mocker.patch(
         "MoBI_View.core.discovery.resolve_streams",
         side_effect=RuntimeError("Network error"),
     )
 
-    inlets, count = discovery.discover_and_create_inlets(wait_time=0.5)
+    inlets, count = discovery.discover_and_create_inlets(wait_time=1.0)
     captured = capsys.readouterr()
 
     assert count == 0
     assert len(inlets) == 0
     assert "Error during stream discovery" in captured.out
+    assert "Network error" in captured.out
 
 
-def test_discover_and_create_inlets_prints_discovered_streams(
+def test_handles_data_inlet_creation_failure(
     mocker: MockFixture,
     mock_stream_info_factory: Callable[..., MagicMock],
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """discover_and_create_inlets should print info about discovered streams."""
-    stream = mock_stream_info_factory(name="TestStream", channel_count=8)
-
+    """Test error handling when DataInlet creation fails for one stream."""
+    bad_stream = mock_stream_info_factory(name="BadStream")
+    good_stream = mock_stream_info_factory(name="GoodStream")
     mocker.patch(
         "MoBI_View.core.discovery.resolve_streams",
-        return_value=[stream],
+        return_value=[bad_stream, good_stream],
     )
 
-    mock_inlet = MagicMock()
-    mock_inlet.stream_name = "TestStream"
-    mock_inlet.stream_type = "EEG"
-    mock_inlet.source_id = "test_source"
-    mock_inlet.channel_count = 8
+    mock_good_inlet = MagicMock(
+        stream_name="GoodStream", stream_type="EEG", channel_count=3
+    )
+    mocker.patch(
+        "MoBI_View.core.discovery.DataInlet",
+        side_effect=[RuntimeError("Invalid channel format"), mock_good_inlet],
+    )
 
-    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_inlet)
-
-    discovery.discover_and_create_inlets(wait_time=0.5)
+    inlets, count = discovery.discover_and_create_inlets(wait_time=1.0)
     captured = capsys.readouterr()
 
-    assert "Discovered new stream: TestStream" in captured.out
-    assert "8 channels" in captured.out
-
-
-def test_discover_and_create_inlets_with_empty_existing_list(
-    mocker: MockFixture,
-    mock_stream_info_factory: Callable[..., MagicMock],
-) -> None:
-    """discover_and_create_inlets should handle empty existing_inlets list."""
-    stream = mock_stream_info_factory(name="Stream1")
-
-    mocker.patch(
-        "MoBI_View.core.discovery.resolve_streams",
-        return_value=[stream],
-    )
-
-    mock_inlet = MagicMock()
-    mock_inlet.stream_name = "Stream1"
-    mock_inlet.stream_type = "EEG"
-    mock_inlet.source_id = "source1"
-    mock_inlet.channel_count = 3
-
-    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_inlet)
-
-    inlets, count = discovery.discover_and_create_inlets(
-        wait_time=0.5,
-        existing_inlets=[],
-    )
-
     assert count == 1
     assert len(inlets) == 1
+    assert inlets[0].stream_name == "GoodStream"
+    assert "Skipping stream BadStream" in captured.out
 
 
-def test_discover_and_create_inlets_deduplicates_by_source_name_type(
+def test_handles_no_streams_discovered(
     mocker: MockFixture,
-    mock_stream_info_factory: Callable[..., MagicMock],
-    mock_data_inlet_factory: Callable[..., MagicMock],
 ) -> None:
-    """discover_and_create_inlets should deduplicate using (name, type)."""
-    existing = mock_data_inlet_factory(
-        stream_name="MyStream",
-        stream_type="EEG",
-    )
+    """Test when resolve_streams() returns an empty list."""
+    mocker.patch("MoBI_View.core.discovery.resolve_streams", return_value=[])
 
-    same_stream = mock_stream_info_factory(
-        name="MyStream",
-        stream_type="EEG",
-    )
+    inlets, count = discovery.discover_and_create_inlets(wait_time=1.0)
 
-    different_stream = mock_stream_info_factory(
-        name="DifferentStream",
-        stream_type="EEG",
-    )
-
-    mocker.patch(
-        "MoBI_View.core.discovery.resolve_streams",
-        return_value=[same_stream, different_stream],
-    )
-
-    mock_new_inlet = MagicMock()
-    mock_new_inlet.stream_name = "DifferentStream"
-    mock_new_inlet.stream_type = "EEG"
-    mock_new_inlet.channel_count = 3
-
-    mocker.patch("MoBI_View.core.discovery.DataInlet", return_value=mock_new_inlet)
-
-    inlets, count = discovery.discover_and_create_inlets(
-        wait_time=0.5,
-        existing_inlets=[existing],
-    )
-
-    assert count == 1
-    assert len(inlets) == 1
+    assert count == 0
+    assert len(inlets) == 0


### PR DESCRIPTION
### Description
This PR introduces a new `discovery.py` module to centralize LSL stream discovery logic, making it reusable. This PR adds `source_id` for better stream identification into DataInlet's metadata. The default wait_time for `pylsl.resolve_stream()` will be set as 1 second as per LSL documentation, with the option to change this value in `config.py` for busy networks. Changed all imports to be at module level, but as`pylsl` module names were too ambiguous, imported them as aliases.

### Changes
- `discovery.py`: Adds `discover_and_create_inlets()` to find, deduplicate, and initialize LSL streams. 
- `main.py`: Replaced inline discovery logic with a call to the new function.
- `test_discovery.py`: Added unit tests for discovery, deduplication, and error handling
- `data_inlet.py`: Adds `source_id`, unique source identifier from `pylsl.StreamInfo.source_id()`, and `sample_rate`, nominal sampling frequency from `pylsl.StreamInfo.nominal_srate()`.
- `test_data_inlet.py`: Added `source_id` into existing unit tests.
- `config.py`: Added `STREAM_RESOLVE_WAIT_TIME`

### Related Issue
Resolves #83
Resolves #84 