### PR TITLE
removing channel visibility from presenter side

### DIFF
--- a/src/MoBI_View/presenters/main_app_presenter.py
+++ b/src/MoBI_View/presenters/main_app_presenter.py
@@ -8,14 +8,13 @@ from MoBI_View.core import config, data_inlet, exceptions
 
 
 class MainAppPresenter:
-    """Presenter managing data inlets and channel visibility.
+    """Presenter managing data inlets and delivering plot data.
 
-    This class processes data from DataInlet instances, manages channel state,
-    and provides data for consumption by external systems (e.g., web servers).
+    This class processes data from DataInlet instances and provides data for
+    consumption by external systems (e.g., web servers).
 
     Attributes:
         data_inlets: A list of DataInlet instances for data acquisition.
-        channel_visibility: A dictionary tracking the visibility of each channel.
     """
 
     def __init__(
@@ -28,16 +27,6 @@ class MainAppPresenter:
             data_inlets: A list of DataInlet instances for data acquisition.
         """
         self.data_inlets: List[data_inlet.DataInlet] = data_inlets
-        self.channel_visibility: Dict[str, bool] = {}
-
-        self._initialize_channels()
-
-    def _initialize_channels(self) -> None:
-        """Initializes channel visibility for all discovered channels."""
-        for inlet in self.data_inlets:
-            for channel_label in inlet.channel_info["labels"]:
-                channel_name = f"{inlet.stream_name}:{channel_label}"
-                self.channel_visibility[channel_name] = True
 
     def poll_data(self) -> List[Dict[str, Any]]:
         """Polls each DataInlet for new data and returns plot data.
@@ -96,12 +85,3 @@ class MainAppPresenter:
             "channel_labels": channel_labels,
         }
         return plot_data
-
-    def update_channel_visibility(self, channel_name: str, visible: bool) -> None:
-        """Updates the visibility of a specific data channel.
-
-        Args:
-            channel_name: The unique name of the channel to toggle.
-            visible: True to show the channel, False to hide it.
-        """
-        self.channel_visibility[channel_name] = visible

--- a/tests/unit/test_main_app_presenter.py
+++ b/tests/unit/test_main_app_presenter.py
@@ -24,11 +24,8 @@ def mock_inlet() -> MagicMock:
 def test_presenter_initialization(mock_inlet: MagicMock) -> None:
     """Tests MainAppPresenter initializes with given data inlets."""
     presenter = main_app_presenter.MainAppPresenter(data_inlets=[mock_inlet])
-    assert presenter.channel_visibility == {
-        "Stream1:Channel1": True,
-        "Stream1:Channel2": True,
-    }
     assert presenter.data_inlets == [mock_inlet]
+    
 
 
 def test_poll_data_success(mock_inlet: MagicMock) -> None:
@@ -99,13 +96,7 @@ def test_poll_data_unexpected_exception(mock_inlet: MagicMock) -> None:
         presenter.poll_data()
 
 
-def test_update_channel_visibility(mock_inlet: MagicMock) -> None:
-    """Tests update_channel_visibility updates visibility state."""
-    presenter = main_app_presenter.MainAppPresenter(data_inlets=[mock_inlet])
 
-    presenter.update_channel_visibility("Stream1:Channel1", False)
-
-    assert presenter.channel_visibility["Stream1:Channel1"] is False
 
 
 def test_on_data_updated(mock_inlet: MagicMock) -> None:

--- a/tests/unit/test_main_app_presenter.py
+++ b/tests/unit/test_main_app_presenter.py
@@ -25,7 +25,6 @@ def test_presenter_initialization(mock_inlet: MagicMock) -> None:
     """Tests MainAppPresenter initializes with given data inlets."""
     presenter = main_app_presenter.MainAppPresenter(data_inlets=[mock_inlet])
     assert presenter.data_inlets == [mock_inlet]
-    
 
 
 def test_poll_data_success(mock_inlet: MagicMock) -> None:
@@ -94,9 +93,6 @@ def test_poll_data_unexpected_exception(mock_inlet: MagicMock) -> None:
 
     with pytest.raises(RuntimeError):
         presenter.poll_data()
-
-
-
 
 
 def test_on_data_updated(mock_inlet: MagicMock) -> None:


### PR DESCRIPTION
### Description
This PR removes the channel visibility management logic. It specifically removes `update_channel_visibility` and `_initialize_channels`, which were responsible for initializing and tracking the visibility state for all discovered channels on the presenter side. In the future, this visibility control will live on the viewer side.

### Changes
- `main_app_presenter.py`: Removed `update_channel_visibility` and `_initialize_channels`.
- `test_main_app_presenter.py`: Removed unit tests related to channel visibility initialization and toggling.

### Related Issue
Resolves #85 