### PR TITLE
feat(web): add static file serving via process_request hook

### DIFF
--- a/src/MoBI_View/web/broadcaster.py
+++ b/src/MoBI_View/web/broadcaster.py
@@ -67,7 +67,7 @@ class Broadcaster:
             return
 
         self._running = True
-        self._thread = threading.Thread(target=lambda: None, daemon=True)
+        self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
         logger.info("Broadcaster started")
 

--- a/src/MoBI_View/web/server.py
+++ b/src/MoBI_View/web/server.py
@@ -1,19 +1,26 @@
 """WebSocket server for MoBI-View real-time data streaming.
 
-This module provides the ws_handler coroutine that manages WebSocket
-client connections and handles incoming discover messages.
+This module provides WebSocket connection handling and static file serving
+via the websockets process_request hook.
 """
 
 import json
 import logging
+import mimetypes
+from pathlib import Path
+from urllib.parse import unquote
 
 from websockets.asyncio import server
+from websockets.datastructures import Headers
+from websockets.http11 import Request, Response
 
 from MoBI_View.core import discovery
 from MoBI_View.presenters import main_app_presenter
 from MoBI_View.web import broadcaster
 
 logger = logging.getLogger("MoBI-View.web.server")
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
 
 
 async def ws_handler(
@@ -96,3 +103,72 @@ async def _handle_discover(
     )
     await websocket.send(response)
     logger.info("Discover: found %d new stream(s)", len(new_inlets))
+
+
+async def process_request(
+    connection: server.ServerConnection,
+    request: Request,
+) -> Response | None:
+    """Serve static files or pass through to WebSocket upgrade.
+
+    Intercepts HTTP requests before the WebSocket handshake. Requests with
+    an ``Upgrade: websocket`` header proceed to ws_handler. All other
+    requests are resolved against the static directory.
+
+    Args:
+        connection: The server connection being handled.
+        request: The incoming HTTP request.
+
+    Returns:
+        A Response for static file requests, or None for WebSocket upgrades.
+    """
+    if _is_websocket_upgrade(request):
+        return None
+    return _serve_static_file(request.path)
+
+
+def _is_websocket_upgrade(request: Request) -> bool:
+    """Check whether the request is a WebSocket upgrade."""
+    return request.headers.get("Upgrade", "").lower() == "websocket"
+
+
+def _serve_static_file(request_path: str) -> Response:
+    """Resolve a URL path to a file in the static directory.
+
+    Decodes percent-encoded characters, normalises the path, and verifies
+    the result stays within STATIC_DIR before reading.
+
+    Args:
+        request_path: The URL path from the HTTP request.
+
+    Returns:
+        An HTTP response with file contents, 404, or 403.
+    """
+    decoded = unquote(request_path)
+    if decoded in ("", "/"):
+        decoded = "/index.html"
+    relative = decoded.lstrip("/")
+    resolved = (STATIC_DIR / relative).resolve()
+    if not _is_within_static_dir(resolved):
+        return _error_response(403, "Forbidden")
+    if not resolved.is_file():
+        return _error_response(404, "Not Found")
+    content_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
+    body = resolved.read_bytes()
+    headers = Headers([("Content-Type", content_type)])
+    return Response(200, "OK", headers, body)
+
+
+def _is_within_static_dir(resolved_path: Path) -> bool:
+    """Verify the resolved path is within the static directory."""
+    try:
+        resolved_path.relative_to(STATIC_DIR)
+        return True
+    except ValueError:
+        return False
+
+
+def _error_response(status_code: int, reason: str) -> Response:
+    """Build a plain-text HTTP error response."""
+    headers = Headers([("Content-Type", "text/plain")])
+    return Response(status_code, reason, headers, reason.encode())

--- a/src/MoBI_View/web/server.py
+++ b/src/MoBI_View/web/server.py
@@ -7,12 +7,11 @@ via the websockets process_request hook.
 import json
 import logging
 import mimetypes
-from pathlib import Path
-from urllib.parse import unquote
+import pathlib
+from urllib import parse
 
+from websockets import datastructures, http11
 from websockets.asyncio import server
-from websockets.datastructures import Headers
-from websockets.http11 import Request, Response
 
 from MoBI_View.core import discovery
 from MoBI_View.presenters import main_app_presenter
@@ -20,7 +19,7 @@ from MoBI_View.web import broadcaster
 
 logger = logging.getLogger("MoBI-View.web.server")
 
-STATIC_DIR = Path(__file__).resolve().parent / "static"
+STATIC_DIR = pathlib.Path(__file__).resolve().parent / "static"
 
 
 async def ws_handler(
@@ -107,8 +106,8 @@ async def _handle_discover(
 
 async def process_request(
     connection: server.ServerConnection,
-    request: Request,
-) -> Response | None:
+    request: http11.Request,
+) -> http11.Response | None:
     """Serve static files or pass through to WebSocket upgrade.
 
     Intercepts HTTP requests before the WebSocket handshake. Requests with
@@ -127,24 +126,32 @@ async def process_request(
     return _serve_static_file(request.path)
 
 
-def _is_websocket_upgrade(request: Request) -> bool:
+def _is_websocket_upgrade(request: http11.Request) -> bool:
     """Check whether the request is a WebSocket upgrade."""
     return request.headers.get("Upgrade", "").lower() == "websocket"
 
 
-def _serve_static_file(request_path: str) -> Response:
+def _serve_static_file(request_path: str) -> http11.Response:
     """Resolve a URL path to a file in the static directory.
 
     Decodes percent-encoded characters, normalises the path, and verifies
     the result stays within STATIC_DIR before reading.
 
+    Two safety checks are applied in order:
+        1. Path containment - if the resolved path escapes STATIC_DIR
+           (e.g. via ``../`` traversal), returns HTTP 403 Forbidden.
+        2. File existence - if the path is inside STATIC_DIR but does
+           not point to an existing file, returns HTTP 404 Not Found.
+
     Args:
         request_path: The URL path from the HTTP request.
 
     Returns:
-        An HTTP response with file contents, 404, or 403.
+        An HTTP 200 response with file contents on success,
+        HTTP 403 Forbidden if the path escapes the static directory,
+        or HTTP 404 Not Found if the file does not exist.
     """
-    decoded = unquote(request_path)
+    decoded = parse.unquote(request_path)
     if decoded in ("", "/"):
         decoded = "/index.html"
     relative = decoded.lstrip("/")
@@ -155,11 +162,11 @@ def _serve_static_file(request_path: str) -> Response:
         return _error_response(404, "Not Found")
     content_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
     body = resolved.read_bytes()
-    headers = Headers([("Content-Type", content_type)])
-    return Response(200, "OK", headers, body)
+    headers = datastructures.Headers([("Content-Type", content_type)])
+    return http11.Response(200, "OK", headers, body)
 
 
-def _is_within_static_dir(resolved_path: Path) -> bool:
+def _is_within_static_dir(resolved_path: pathlib.Path) -> bool:
     """Verify the resolved path is within the static directory."""
     try:
         resolved_path.relative_to(STATIC_DIR)
@@ -168,7 +175,7 @@ def _is_within_static_dir(resolved_path: Path) -> bool:
         return False
 
 
-def _error_response(status_code: int, reason: str) -> Response:
+def _error_response(status_code: int, reason: str) -> http11.Response:
     """Build a plain-text HTTP error response."""
-    headers = Headers([("Content-Type", "text/plain")])
-    return Response(status_code, reason, headers, reason.encode())
+    headers = datastructures.Headers([("Content-Type", "text/plain")])
+    return http11.Response(status_code, reason, headers, reason.encode())

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -204,3 +205,148 @@ def test_handle_discover_with_no_new_streams(
 
     sent = json.loads(mock_websocket.send.call_args[0][0])
     assert sent["streams"] == []
+
+
+@pytest.fixture
+def static_dir(tmp_path: Path) -> Path:
+    """Creates a temporary static directory with test files."""
+    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "style.css").write_text("body {}")
+    sub = tmp_path / "js"
+    sub.mkdir()
+    (sub / "app.js").write_text("console.log('ok')")
+    return tmp_path
+
+
+def _make_request(path: str, upgrade: str = "") -> MagicMock:
+    """Builds a minimal Request-like object with path and headers."""
+    from websockets.datastructures import Headers
+
+    header_list = []
+    if upgrade:
+        header_list.append(("Upgrade", upgrade))
+    request = MagicMock()
+    request.path = path
+    request.headers = Headers(header_list)
+    return request
+
+
+def test_process_request_passes_websocket_upgrades() -> None:
+    """Tests process_request returns None for WebSocket upgrades."""
+    request = _make_request("/", upgrade="websocket")
+    connection = MagicMock()
+
+    result = asyncio.run(server.process_request(connection, request))
+
+    assert result is None
+
+
+def test_process_request_serves_static_file(
+    static_dir: Path,
+) -> None:
+    """Tests process_request returns file contents for a valid path."""
+    request = _make_request("/style.css")
+    connection = MagicMock()
+
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = asyncio.run(server.process_request(connection, request))
+
+    assert result is not None
+    assert result.status_code == 200
+    assert b"body {}" in result.body
+
+
+def test_serve_static_file_returns_index_for_root(
+    static_dir: Path,
+) -> None:
+    """Tests root path resolves to index.html."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file("/")
+
+    assert result.status_code == 200
+    assert b"<html></html>" in result.body
+
+
+def test_serve_static_file_returns_index_for_empty_path(
+    static_dir: Path,
+) -> None:
+    """Tests empty path resolves to index.html."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file("")
+
+    assert result.status_code == 200
+
+
+def test_serve_static_file_returns_nested_file(
+    static_dir: Path,
+) -> None:
+    """Tests subdirectory files are served correctly."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file("/js/app.js")
+
+    assert result.status_code == 200
+    assert b"console.log" in result.body
+
+
+def test_serve_static_file_returns_correct_content_type(
+    static_dir: Path,
+) -> None:
+    """Tests Content-Type header matches the file extension."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file("/style.css")
+
+    assert result.status_code == 200
+    assert "css" in result.headers.get("Content-Type", "")
+
+
+def test_serve_static_file_returns_404_for_missing_file(
+    static_dir: Path,
+) -> None:
+    """Tests missing files return a 404 response."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file("/nope.txt")
+
+    assert result.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        "/../../../etc/passwd",
+        "/%2e%2e/%2e%2e/etc/passwd",
+        "/..%2F..%2Fetc/passwd",
+    ],
+)
+def test_serve_static_file_blocks_path_traversal(
+    malicious_path: str, static_dir: Path
+) -> None:
+    """Tests path traversal attempts return a 403 response."""
+    with patch.object(server, "STATIC_DIR", static_dir):
+        result = server._serve_static_file(malicious_path)
+
+    assert result.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "resolved,expected",
+    [
+        ("inside", True),
+        ("outside", False),
+    ],
+)
+def test_is_within_static_dir(
+    resolved: str,
+    expected: bool,
+    tmp_path: Path,
+) -> None:
+    """Tests path containment check against the static directory."""
+    static = tmp_path / "static"
+    static.mkdir()
+
+    if resolved == "inside":
+        target = static / "file.html"
+    else:
+        target = tmp_path / "file.html"
+
+    with patch.object(server, "STATIC_DIR", static):
+        assert server._is_within_static_dir(target) is expected

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,10 +2,11 @@
 
 import asyncio
 import json
-from pathlib import Path
+import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from websockets import datastructures
 
 from MoBI_View.presenters import main_app_presenter
 from MoBI_View.web import broadcaster, server
@@ -208,26 +209,24 @@ def test_handle_discover_with_no_new_streams(
 
 
 @pytest.fixture
-def static_dir(tmp_path: Path) -> Path:
-    """Creates a temporary static directory with test files."""
+def static_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Creates a temporary static directory mimicking SvelteKit build output."""
     (tmp_path / "index.html").write_text("<html></html>")
     (tmp_path / "style.css").write_text("body {}")
-    sub = tmp_path / "js"
-    sub.mkdir()
-    (sub / "app.js").write_text("console.log('ok')")
+    app_dir = tmp_path / "_app" / "immutable"
+    app_dir.mkdir(parents=True)
+    (app_dir / "entry.js").write_text("console.log('ok')")
     return tmp_path
 
 
 def _make_request(path: str, upgrade: str = "") -> MagicMock:
     """Builds a minimal Request-like object with path and headers."""
-    from websockets.datastructures import Headers
-
     header_list = []
     if upgrade:
         header_list.append(("Upgrade", upgrade))
     request = MagicMock()
     request.path = path
-    request.headers = Headers(header_list)
+    request.headers = datastructures.Headers(header_list)
     return request
 
 
@@ -241,55 +240,47 @@ def test_process_request_passes_websocket_upgrades() -> None:
     assert result is None
 
 
-def test_process_request_serves_static_file(
-    static_dir: Path,
-) -> None:
-    """Tests process_request returns file contents for a valid path."""
+def test_process_request_serves_static_file() -> None:
+    """Tests process_request delegates to _serve_static_file for HTTP requests."""
     request = _make_request("/style.css")
     connection = MagicMock()
+    fake_response = MagicMock()
 
-    with patch.object(server, "STATIC_DIR", static_dir):
+    with patch.object(
+        server, "_serve_static_file", return_value=fake_response
+    ) as mock_serve:
         result = asyncio.run(server.process_request(connection, request))
 
-    assert result is not None
-    assert result.status_code == 200
-    assert b"body {}" in result.body
+    mock_serve.assert_called_once_with("/style.css")
+    assert result is fake_response
 
 
-def test_serve_static_file_returns_index_for_root(
-    static_dir: Path,
+@pytest.mark.parametrize("path", ["/", ""])
+def test_serve_static_file_returns_index_for_root_paths(
+    path: str,
+    static_dir: pathlib.Path,
 ) -> None:
-    """Tests root path resolves to index.html."""
+    """Tests root and empty paths both resolve to index.html."""
     with patch.object(server, "STATIC_DIR", static_dir):
-        result = server._serve_static_file("/")
+        result = server._serve_static_file(path)
 
     assert result.status_code == 200
     assert b"<html></html>" in result.body
 
 
-def test_serve_static_file_returns_index_for_empty_path(
-    static_dir: Path,
-) -> None:
-    """Tests empty path resolves to index.html."""
-    with patch.object(server, "STATIC_DIR", static_dir):
-        result = server._serve_static_file("")
-
-    assert result.status_code == 200
-
-
 def test_serve_static_file_returns_nested_file(
-    static_dir: Path,
+    static_dir: pathlib.Path,
 ) -> None:
     """Tests subdirectory files are served correctly."""
     with patch.object(server, "STATIC_DIR", static_dir):
-        result = server._serve_static_file("/js/app.js")
+        result = server._serve_static_file("/_app/immutable/entry.js")
 
     assert result.status_code == 200
     assert b"console.log" in result.body
 
 
 def test_serve_static_file_returns_correct_content_type(
-    static_dir: Path,
+    static_dir: pathlib.Path,
 ) -> None:
     """Tests Content-Type header matches the file extension."""
     with patch.object(server, "STATIC_DIR", static_dir):
@@ -300,7 +291,7 @@ def test_serve_static_file_returns_correct_content_type(
 
 
 def test_serve_static_file_returns_404_for_missing_file(
-    static_dir: Path,
+    static_dir: pathlib.Path,
 ) -> None:
     """Tests missing files return a 404 response."""
     with patch.object(server, "STATIC_DIR", static_dir):
@@ -318,7 +309,7 @@ def test_serve_static_file_returns_404_for_missing_file(
     ],
 )
 def test_serve_static_file_blocks_path_traversal(
-    malicious_path: str, static_dir: Path
+    malicious_path: str, static_dir: pathlib.Path
 ) -> None:
     """Tests path traversal attempts return a 403 response."""
     with patch.object(server, "STATIC_DIR", static_dir):
@@ -337,7 +328,7 @@ def test_serve_static_file_blocks_path_traversal(
 def test_is_within_static_dir(
     resolved: str,
     expected: bool,
-    tmp_path: Path,
+    tmp_path: pathlib.Path,
 ) -> None:
     """Tests path containment check against the static directory."""
     static = tmp_path / "static"


### PR DESCRIPTION
Adds static file serving to the WebSocket server so the upcoming SvelteKit frontend can be served from the same port.

The websockets library has a `process_request` hook that fires before every WebSocket handshake. We use it to check whether the incoming request is a regular HTTP request (no `Upgrade` header) and if so, serve the file from `web/static/`. WebSocket connections pass through to `ws_handler` as before.

Path traversal is handled by resolving the requested path and checking it stays inside `STATIC_DIR` via `Path.relative_to()`. Percent encoded characters are decoded first so tricks like `%2e%2e` don't bypass the check.

New helper functions `_is_websocket_upgrade`, `_serve_static_file`, `_is_within_static_dir`, `_error_response` added.