### PR TITLE
fix(web): send broadcast frames on the server event loop

### DIFF
--- a/src/MoBI_View/web/broadcaster.py
+++ b/src/MoBI_View/web/broadcaster.py
@@ -59,12 +59,20 @@ class Broadcaster:
     def start(self) -> None:
         """Starts the broadcast loop in a background thread.
 
-        Creates a new thread running the broadcast loop. If already running,
-        this method does nothing.
+        Captures the currently running event loop (the web server's loop) so the
+        background thread can schedule client sends on it via
+        ``run_coroutine_threadsafe``. WebSocket connections are owned by that
+        loop, so sends must be dispatched there rather than on a loop created in
+        this thread. If already running, this method does nothing.
         """
         if self._running:
             logger.warning("Broadcaster already running")
             return
+
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
 
         self._running = True
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -137,12 +145,10 @@ class Broadcaster:
     def _run(self) -> None:
         """Main broadcast loop running in background thread.
 
-        Continuously polls the presenter for data, formats it, and broadcasts
-        to all connected clients. Runs until stop() is called.
+        Continuously polls the presenter for data, formats it, and broadcasts it
+        to all connected clients on the server event loop captured in start().
+        Runs until stop() is called.
         """
-        self._loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._loop)
-
         logger.info("Broadcast loop started")
 
         while self._running:
@@ -159,7 +165,6 @@ class Broadcaster:
                 logger.error("Error in broadcast loop: %s", err)
                 time.sleep(self.broadcast_interval)
 
-        self._loop.close()
         logger.info("Broadcast loop ended")
 
     def _broadcast_to_clients(self, message: str) -> None:

--- a/tests/unit/test_broadcaster.py
+++ b/tests/unit/test_broadcaster.py
@@ -291,12 +291,12 @@ def test_format_frame_multiple_streams(
     assert parsed["streams"][1]["stream_name"] == "Accelerometer"
 
 
-def test_run_creates_and_closes_event_loop(
+def test_run_logs_start_and_end(
     broadcaster_instance: broadcaster.Broadcaster,
     mock_presenter: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Tests _run() creates event loop, logs start/end, and closes loop on exit."""
+    """Tests _run() logs start/end and does not create its own event loop."""
     broadcaster_instance._running = True
 
     def stop_after_one_iteration() -> None:
@@ -309,8 +309,7 @@ def test_run_creates_and_closes_event_loop(
 
     assert "Broadcast loop started" in caplog.text
     assert "Broadcast loop ended" in caplog.text
-    assert broadcaster_instance._loop is not None
-    assert broadcaster_instance._loop.is_closed()
+    assert broadcaster_instance._loop is None
 
 
 def test_run_polls_presenter_for_data(


### PR DESCRIPTION
## Summary
Fixes live WebSocket broadcasting so connected browser clients actually receive stream frames instead of timing out and being dropped.

The `Broadcaster` polls data in a background thread and uses `run_coroutine_threadsafe(...)` to send frames to connected WebSocket clients.

The broadcaster created a new event loop inside the background thread and scheduled `client.send(...)` onto that loop. That loop was never actually running, and the WebSocket connections themselves are owned by the web server's asyncio loop.

Resolves #127 

## Changes
- Capture the running server event loop when the broadcaster starts.
- Use that server loop for `run_coroutine_threadsafe(client.send(...), loop)`.
- Remove the unused event loop created in the broadcaster thread.
- Update the broadcaster unit test that previously expected `_run()` to create and close its own event loop.